### PR TITLE
Remove Jack, add retrolambda.

### DIFF
--- a/BankChain/app/build.gradle
+++ b/BankChain/app/build.gradle
@@ -1,15 +1,18 @@
 buildscript {
     repositories {
         jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
+        classpath 'me.tatarka:gradle-retrolambda:3.6.1'
     }
 }
 
 apply plugin: 'com.android.application'
 apply from: '../config/quality/quality.gradle'
 apply plugin: 'jacoco-android'
+apply plugin: 'me.tatarka.retrolambda'
 
 android {
     compileSdkVersion 25
@@ -21,10 +24,6 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        jackOptions {
-            enabled true
-            additionalParameters("jack.incremental": "true")
-        }
     }
     lintOptions {
         abortOnError false
@@ -48,9 +47,16 @@ android {
     }
 }
 
+retrolambda {
+    javaVersion JavaVersion.VERSION_1_7
+    defaultMethods false
+    incremental true
+}
+
 repositories {
     jcenter()
     maven { url "https://jitpack.io" }
+    mavenCentral()
 }
 
 dependencies {

--- a/BankChain/gradle.properties
+++ b/BankChain/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx2560M
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
RetroLambda is said to be much faster than Jack. It is true.
Build times have folded 20x on initial build, and 100x+ on
incremental builds.

Try it