### PR TITLE
Add Better Code Hub configuration

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,4 +1,4 @@
 # BankChain/app/src/main/java/nl/tudelft/ewi/ds/bankchain/XXX
-component_depth: 10
+component_depth: 11
 languages:
 - java

--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,2 @@
+# BankChain/app/src/main/java/nl/tudelft/ewi/ds/bankchain/XXX
+component_depth: 11

--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,2 +1,4 @@
 # BankChain/app/src/main/java/nl/tudelft/ewi/ds/bankchain/XXX
-component_depth: 11
+component_depth: 10
+languages:
+- java

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/MatthijsKok/TI2806-Contextproject.svg?branch=develop)](https://travis-ci.org/MatthijsKok/TI2806-Contextproject)
 [![codecov](https://codecov.io/gh/MatthijsKok/TI2806-Contextproject/branch/develop/graph/badge.svg)](https://codecov.io/gh/MatthijsKok/TI2806-Contextproject)
+[![BCH compliance](https://bettercodehub.com/edge/badge/MatthijsKok/TI2806-Contextproject?branch=develop)](https://bettercodehub.com/)
 
 BankChain: increasing trust on the blockchain using IBAN verification
 =====================================================================


### PR DESCRIPTION
As per the documentation, I have added the correct component depth. One of our failing items is that it can only find a single architectural component. That is false. I had to configure how deep it finds the components.

I also added a nice button to the readme.